### PR TITLE
Add results object

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,41 @@
 nypl-digital-collections
 ========================
 
-Library to access the New York Public Library's Digital Collections API
+Library to access the New York Public Library's [Digital Collections API](http://api.repo.nypl.org).
+
+Basics: 
+
+````python
+from nyplcollections import NYPLsearch
+
+# Create search object
+nypl = NYPLsearch(API_KEY)
+````
+
+Methods:
+* NYPLsearch.captures
+* NYPLsearch.mods
+* NYPLsearch.search
+* NYPLsearch.uuid
+
+Search:
+
+````python
+cats = self.nypl.search('cats')
+
+cats.results
+# [...]
+````
+
+MODS:
+
+````python
+# Get a MODS record based on uuid
+mods = nypl.mods('acfeeb2d-7c5e-4ce7-e040-e00a180644aa')
+
+mods.status_code
+200
+
+mods.results
+# {...}
+````

--- a/nyplcollections/__init__.py
+++ b/nyplcollections/__init__.py
@@ -1,1 +1,2 @@
+__all__ = ['nyplcollections']
 from .nyplcollections import NYPLsearch

--- a/nyplcollections/nyplcollections.py
+++ b/nyplcollections/nyplcollections.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python
 
 import requests
-import xmltodict
 
 class NYPLsearch(object):
     raw_results = ''
     request = dict()
     error = None
 
-    def __init__(self, token, format=None, page=None, per_page=None):
+    def __init__(self, token, page=None, per_page=None):
         self.token = token
-        self.format = format or 'json'
+        self.format = 'json'
         self.page = page or 1
         self.per_page = per_page or 10
         self.base = "http://api.repo.nypl.org/api/v1/items"
@@ -60,10 +59,10 @@ class NYPLsearch(object):
                          headers=headers)
 
         self.raw_results = r.text
-        results = self._to_dict(r)['nyplAPI']['response']
 
         self.headers = results['headers']
         self.request = r.json()['nyplAPI'].get('request', dict())
+        results = r.json()['nyplAPI']['response']
 
         if self.headers['status'] == 'error':
             self.error = {
@@ -73,7 +72,4 @@ class NYPLsearch(object):
         else:
             self.error = None
 
-        return picker(results)
 
-    def _to_dict(self, r):
-        return r.json() if self.format == 'json' else xmltodict.parse(r.text)

--- a/nyplcollections/nyplcollections.py
+++ b/nyplcollections/nyplcollections.py
@@ -16,32 +16,32 @@ class NYPLsearch(object):
         self.format = format
         self.base = "http://api.repo.nypl.org/api/v1/items"
 
-    # Return the captures for a given uuid
-    # optional value withTitles=yes
     def captures(self, uuid, withTitles=False):
+        """Return the captures for a given uuid
+            optional value withTitles=yes"""
         return self._get('/'.join([self.base, uuid]),
                          {'withTitles': 'yes' if withTitles else 'no'})
 
-    # Return the item-uuid for a identifier.
     def uuid(self, type, val):
+        """Return the item-uuid for a identifier"""
         return self._get('/'.join([self.base, type, val]))
 
-    # Search across all (without field) or in specific field
-    # (valid fields at http://www.loc.gov/standards/mods/mods-outline.html)
     def search(self, q, field=None):
+        """Search across all (without field) or in specific field
+        (valid fields at http://www.loc.gov/standards/mods/mods-outline.html)"""
         params = {'q': q}
         if field:
             params['field'] = field
 
         return self._get('/'.join([self.base, 'search']), params)
 
-    # Return a mods record for a given uuid
     def mods(self, uuid):
+        """Return a mods record for a given uuid"""
         return self._get('/'.join([self.base, 'mods', uuid]))
 
-    # Generic get which handles call to api and setting of results
-    # Return: results dict
     def _get(self, url, params=None):
+        """Generic get which handles call to api and setting of results
+        Return: Results object"""
         self.raw_results = self.results = None
 
         headers = {"Authorization": "Token token=" + self.token}

--- a/nyplcollections/nyplcollections.py
+++ b/nyplcollections/nyplcollections.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import requests
 
+
 class NYPLsearch(object):
 
     def __init__(self, token, page=None, per_page=None):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ setup(
     author="nick mohoric",
     author_email="nick.mohoric@gmail.com",
     install_requires=[
-        "xmltodict",
         "requests"
     ],
     packages=['nyplcollections'],

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="nyplcollections",
-    version="1",
+    version="1.1",
     description="new york public library image collections api",
     author="nick mohoric",
     author_email="nick.mohoric@gmail.com",

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,0 +1,73 @@
+from nyplcollections import NYPLsearch
+import unittest
+
+# todo: use mock to mock in NYPL responses
+
+KEY = # insert your key here
+
+class TestNYPLsearch(unittest.TestCase):
+
+    def setUp(self):
+        self.nypl = NYPLsearch(KEY)
+
+    def test_search(self):
+        cats = self.nypl.search('cats')
+
+        assert 200 == cats.status_code
+
+        assert cats.request['perPage'] == 10
+
+        assert cats.results
+
+        assert len(cats.results)
+
+        assert cats.results[0].get('uuid')
+
+
+    def test_next(self):
+        cats = self.nypl.search('cats')
+        mor_cats = next(cats)
+        assert 200 == mor_cats.status_code
+
+    def test_search_fields(self):
+        maps = self.nypl.search('cartographic', field='typeOfResource')
+
+        assert 200 == maps.status_code
+
+        assert maps.results
+
+        assert maps.results[0].get('uuid')
+
+    def test_per_page(self):
+        cats = self.nypl.search('cats', per_page=1)
+        assert len(cats.results) == 1
+
+    def test_mods(self):
+        uuid = '510d47dd-ab68-a3d9-e040-e00a18064a99'
+        hades = '423990'
+        mods = self.nypl.mods(uuid)
+        assert 200 == mods.status_code
+
+        identifiers = mods.results['identifier']
+        u = [i for i in identifiers if i['type'] == 'local_hades']
+        assert u[0]['$'] == hades
+
+        assert mods.results['titleInfo'][1]['title']['$'] == u'Gowanus Bay - Brooklyn - 30th Street Pier.'
+
+    def test_uuid(self):
+        uuid = self.nypl.uuid('local_hades', '1017240')
+
+        assert 200 == uuid.status_code
+        assert 'ecaf7d80-c55f-012f-e3c7-58d385a7bc34' == uuid.results
+
+    def test_captures(self):
+        captures = self.nypl.captures('5fa75050-c6c7-012f-e24b-58d385a7bc34')
+
+        assert 200 == captures.status_code
+
+        assert 125 == captures.count
+
+        assert type(captures.results) == list
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/testsample.py
+++ b/tests/testsample.py
@@ -1,4 +1,0 @@
-import NYPLsearch
-
-def test_numbers_3_4():
-    assert 3 * 4 == 12 


### PR DESCRIPTION
As promised, this update adds a `Result` object. It has a limited set of attributes: 
- raw (str, requests.text)
- status_code (int, requests.status_code)
- headers (dict, the headers object from the API response)
- request (dict, the request object ditto.)
- results (dict or list)
- next (function, a function that returns the next page of reults)

`Result.results` is usually a list, but a dict for `NYPLsearch.mods` queries.

I also removed the format parameter and the XML feature. It couldn't figure out when it would be useful. If someone wants to manipulate raw XML, they can use the `Result.raw` and their favorite XML parser. 

I also added some test cases, and the beginnings of a readme file.
